### PR TITLE
Removed Authentik from Baikal.

### DIFF
--- a/baikal/docker-compose.yml
+++ b/baikal/docker-compose.yml
@@ -27,4 +27,3 @@ services:
       - "traefik.http.routers.baikal-secure.rule=Host(`baikal.your-domain.com`)"
       - "traefik.http.routers.baikal-secure.tls=true"
       - "traefik.http.services.baikal.loadbalancer.server.port=80"
-      - "traefik.http.routers.baikal-secure.middlewares=authentik@file"


### PR DESCRIPTION
Removed Authentik from Baikal due to no DAVx5 support during sync and initial login.